### PR TITLE
Add tame supersaw engine

### DIFF
--- a/dronecaster.lua
+++ b/dronecaster.lua
@@ -9,6 +9,7 @@
 -- ........................................
 -- contributors:
 -- "Mt. Zion" by @license
+-- "Supersaw" by @cfd90
 -- ........................................
 -- l.llllllll.co/dronecaster
 -- <3 @tyleretters
@@ -27,7 +28,7 @@ save_path = _path.audio .. "dronecaster/"
 amp_default = 1.0
 hz_default = 55
 drone_default = 1
-drones = {"Mt. Zion", "Sine"}
+drones = {"Mt. Zion", "Sine", "Supersaw"}
 recording = false
 playing = false
 filename = filename_prefix
@@ -66,7 +67,7 @@ function init()
   params:set_action("amp", function(x) update_amp(x) end)
   params:add_control("hz", "hz", controlspec.new(0, 20000, "lin", 0, hz_default, "hz"))
   params:set_action("hz", function(x) update_hz(x) end)
-  params:add_control("drone","drone",controlspec.new(1, 2, "lin", 0, drone_default, "drone"))
+  params:add_control("drone","drone",controlspec.new(1, #drones, "lin", 0, drone_default, "drone"))
   params:set_action("drone", function(x) update_drone(x) end)
   engine.stop(1) -- todo: how to not have the engine automatically start?
 end
@@ -174,10 +175,13 @@ function key(n, z)
 end
 
 function play_drone()
-    if params:get("drone") == 1 then
+    drone = params:get("drone")
+    if drone == 1 then
       engine.start_zion(1)
-    else
+    elseif drone == 2 then
       engine.start_sine(1)
+    elseif drone == 3 then
+      engine.start_supersaw(1)
     end
     engine.amp(params:get("amp"))
     engine.hz(params:get("hz"))

--- a/engine/Engine_Dronecaster.sc
+++ b/engine/Engine_Dronecaster.sc
@@ -49,6 +49,20 @@
       });
       Out.ar(out, voices);
     }).add;
+
+    SynthDef(\Supersaw, {
+      arg out, hz=440, amp=0.02, amplag=0.02, hzlag=0.01;
+      var amp_, hz_;
+      amp_ = Lag.ar(K2A.ar(amp), amplag);
+      hz_ = Lag.ar(K2A.ar(hz), hzlag);
+      Out.ar(out, Splay.ar(Array.fill(5, { |i|
+        BPF.ar(
+          Saw.ar(hz_ * i + SinOsc.kr(0.1 * i, 0, 0.5)),
+          100 + (i * 100) + SinOsc.kr(0.05 * i, mul: 100),
+          2
+        )
+      }), 1) * amp_);
+    }).add;
     
     context.server.sync;
     
@@ -74,6 +88,10 @@
 
     this.addCommand("start_zion", "i", { arg msg;
       synth = Synth.new(\Zion, [\out, context.out_b], context.xg);
+    });
+    
+    this.addCommand("start_supersaw", "i", { arg msg;
+      synth = Synth.new(\Supersaw, [\out, context.out_b], context.xg);
     });
     
     // this.addCommand("injack", "s", { arg msg;


### PR DESCRIPTION
- Adds a kind of tame supersaw-ish engine: a handful of saw wave partials piped through low BPFs with subtle modulation
- Defines the maximum value of `drone` param with `#drones`, so it doesn't need updated when new synths are added

Edit: hearing some issues with overlapping drones playing when I'm switching engines, taking a look...