### PR TITLE
Set to play when selecting drone

### DIFF
--- a/dronecaster.lua
+++ b/dronecaster.lua
@@ -126,6 +126,7 @@ function update_drone(x)
   if playing then
     stop_drone()
   end
+  playing = true
   -- print(round(params:get("drone"))
   -- engine.drone(round(params:get("drone")))
   play_drone()


### PR DESCRIPTION
This is a cheap fix for the bug where the singleton drone was not being enforced, i.e. you could create an indefinite number of drones when casting was not started yet by simpling flipping between different drones. A better solution might be to update drone type separate from starting playback, although this bug only occurs before casting.