### PR TITLE
Mix Mt. Zion voice mix

### DIFF
--- a/engine/Engine_Dronecaster.sc
+++ b/engine/Engine_Dronecaster.sc
@@ -47,7 +47,7 @@
           rand.(0.1, maxAmp)
         );
       });
-      Out.ar(out, voices);
+      Out.ar(out, Mix.ar(voices));
     }).add;
     
     context.server.sync;


### PR DESCRIPTION
Only 2 of the Mt. Zion voices were audible because the `Mix.ar` was missing. This adds it so you get all 5 voices spread across the stereo field.