### PR TITLE
Refactor drone selection

### DIFF
--- a/dronecaster.lua
+++ b/dronecaster.lua
@@ -28,7 +28,8 @@ save_path = _path.audio .. "dronecaster/"
 amp_default = .4
 hz_default = 55
 drone_default = 1
-drones = {"Mt. Zion", "Sine", "Supersaw", "Mt. Lion",}
+-- drones = {"Mt. Zion", "Sine", "Supersaw", "Mt. Lion",}
+drones = {}
 recording = false
 playing = false
 counter = metro.init()
@@ -176,7 +177,7 @@ end
 function play_drone()
     drone = params:get("drone")
     if drone > 0 and drone <= #drones then
-      engine.start_drone(drone - 1)
+      engine.start(drone - 1)
     end
     engine.amp(params:get("amp"))
     engine.hz(params:get("hz"))
@@ -199,3 +200,12 @@ function round(num, places)
   end
   return math.floor(num + 0.5)
 end
+
+function osc_in(path, msg)
+  if path == "/add_drone" then
+    print("adding drone" .. msg[1])
+    table.insert(drones, msg[1])
+  end
+end
+
+osc.event = osc_in -- should probably go in init? race conditions tho?

--- a/dronecaster.lua
+++ b/dronecaster.lua
@@ -112,15 +112,11 @@ function redraw()
 end
 
 function update_hz(x)
-  if playing then 
-    engine.hz(x)
-  end
+  engine.hz(x)
 end
 
 function update_amp(x)
-  if playing then
-    engine.amp(x)
-  end
+  engine.amp(x)
 end
 
 function update_drone(x)
@@ -175,12 +171,10 @@ function key(n, z)
 end
 
 function play_drone()
-    drone = params:get("drone")
-    if drone > 0 and drone <= #drones then
-      engine.start(drone - 1)
+    local droneIndex = params:get("drone")
+    if droneIndex > 0 and droneIndex <= #drones then
+      engine.start(drones[droneIndex])
     end
-    engine.amp(params:get("amp"))
-    engine.hz(params:get("hz"))
 end
 
 function stop_drone()

--- a/dronecaster.lua
+++ b/dronecaster.lua
@@ -175,14 +175,8 @@ end
 
 function play_drone()
     drone = params:get("drone")
-    if drone == 1 then
-      engine.start_zion(1)
-    elseif drone == 2 then
-      engine.start_sine(1)
-    elseif drone == 3 then
-      engine.start_supersaw(1) 
-    elseif drone == 4 then
-        engine.start_lion(1)
+    if drone > 0 and drone <= #drones then
+      engine.start_drone(drone - 1)
     end
     engine.amp(params:get("amp"))
     engine.hz(params:get("hz"))

--- a/dronecaster.lua
+++ b/dronecaster.lua
@@ -28,7 +28,6 @@ save_path = _path.audio .. "dronecaster/"
 amp_default = .4
 hz_default = 55
 drone_default = 1
--- drones = {"Mt. Zion", "Sine", "Supersaw", "Mt. Lion",}
 drones = {}
 recording = false
 playing = false
@@ -64,12 +63,11 @@ function init()
   counter.event = the_sands_of_time
   counter:start()
   params:add_control("amp", "amp", controlspec.new(0, 1, "amp", 0, amp_default, "amp"))
-  params:set_action("amp", function(x) update_amp(x) end)
+  params:set_action("amp", engine.amp)
   params:add_control("hz", "hz", controlspec.new(0, 20000, "lin", 0, hz_default, "hz"))
-  params:set_action("hz", function(x) update_hz(x) end)
+  params:set_action("hz", engine.hz)
   params:add_control("drone","drone",controlspec.new(1, #drones, "lin", 0, drone_default, "drone"))
-  params:set_action("drone", function(x) update_drone(x) end)
-  engine.stop(1) -- todo: how to not have the engine automatically start?
+  params:set_action("drone", play_drone)
 end
 
 function the_sands_of_time()
@@ -111,24 +109,6 @@ function redraw()
   screen.update()
 end
 
-function update_hz(x)
-  engine.hz(x)
-end
-
-function update_amp(x)
-  engine.amp(x)
-end
-
-function update_drone(x)
-  if playing then
-    stop_drone()
-  end
-  playing = true
-  -- print(round(params:get("drone"))
-  -- engine.drone(round(params:get("drone")))
-  play_drone()
-end
-
 -- encs & keys
 --------------------------------------------------------------------------------
 function enc(n,d)
@@ -163,7 +143,7 @@ function key(n, z)
       play_drone()
       alert["casting_message"] = messages["start_casting"]
     else
-      stop_drone()
+      engine.stop(1)
       alert["casting_message"] = messages["stop_casting"]
     end
   end
@@ -172,13 +152,10 @@ end
 
 function play_drone()
     local droneIndex = params:get("drone")
+    playing = true
     if droneIndex > 0 and droneIndex <= #drones then
       engine.start(drones[droneIndex])
     end
-end
-
-function stop_drone()
-  engine.stop(1)
 end
 
 -- utils

--- a/engine/Engine_Dronecaster.sc
+++ b/engine/Engine_Dronecaster.sc
@@ -8,6 +8,13 @@
   }
 
   alloc {
+    // TODO:
+    // [ ] Get path of this file
+    // [ ] Get dir from path
+    // [ ] Get all files in subdir "drones"
+    // [ ] Create dict of name -> implementation (from contents)
+    // [ ] Shake hands via OSC if necessary (race condition?)
+    // [ ] Notify Lua of names via OSC
 
     // SynthDef(\InJacks, {
     //   arg out;
@@ -19,91 +26,13 @@
     // TODO: Lookup by string (name).
     // Meanwhile, order below *must* match drones var in Lua!
     drones = [
-      // @license
-      // Thee rusted satellites gather + sing.
-      "Mt. Zion" -> {
-        arg out, hz=55.1, amp=0.02, amplag=0.02, hzlag=0.01;
-        var amp_ = Lag.ar(K2A.ar(amp), amplag);
-        var hz_ = Lag.ar(K2A.ar(hz), hzlag);
-        var voiceCount = 5;
-        var baseNote = hz_.cpsmidi.round;
-        var noteDetune = (baseNote - hz_.cpsmidi).abs;
-        var maxAmp = amp_ / voiceCount;
-        
-        var rand = ({|sampleFreq=1, mul=1, add=0, lag=0.5|
-          Latch.ar(WhiteNoise.ar(mul, add), Dust.ar(sampleFreq)).lag(lag)
-        });
-        
-        var voices = (1..voiceCount).collect({ |index|
-          Pan2.ar(
-            Pulse.ar(
-              rand.(0.2, noteDetune, baseNote, 2).midicps * index,
-              rand.(0.5, 0.5, 1.5)
-            ),
-            rand.(0.3),
-            rand.(0.1, maxAmp)
-          );
-        });
-        Out.ar(out, Mix.ar(voices));
-      },
+      /*"Mt. Zion" -> ,
 
-      // The TestSine. Old faithful.
-      "Sine" -> {
-        arg out, hz=440, amp=0.02, amplag=0.02, hzlag=0.01;
-        var amp_, hz_;
-        amp_ = Lag.ar(K2A.ar(amp), amplag);
-        hz_ = Lag.ar(K2A.ar(hz), hzlag);
-        Out.ar(out, (SinOsc.ar(hz_) * amp_).dup);
-      }, 
+      "Sine" -> , 
 
-      // @cfdrake
-      "Supersaw" -> {
-        arg out, hz=440, amp=0.02, amplag=0.02, hzlag=0.01;
-        var amp_, hz_;
-        amp_ = Lag.ar(K2A.ar(amp), amplag);
-        hz_ = Lag.ar(K2A.ar(hz), hzlag);
-        Out.ar(out, Splay.ar(Array.fill(5, { |i|
-          BPF.ar(
-            Saw.ar(hz_ * i + SinOsc.kr(0.1 * i, 0, 0.5)),
-            100 + (i * 100) + SinOsc.kr(0.05 * i, mul: 100),
-            2
-          )
-        }), 1) * amp_);
-      }, 
+      "Supersaw" -> , 
 
-      // @license
-      // Roars through a twisting canyon.
-      "Mt. Lion" -> {
-        arg out, hz=55.1, amp=0.02, amplag=0.02, hzlag=0.01;
-        var amp_ = amp.lag(amplag);
-        var hz_ = hz.lag(hzlag);
-        var voiceCount = 9;
-        var baseNote = hz_.cpsmidi.round;
-        var noteDetune = (baseNote - hz_.cpsmidi).abs;
-        var maxAmp = amp_ / voiceCount;
-
-        var rand = ({|sampleFreq=1, mul=1, add=0, lag=0.5|
-          Latch.kr(WhiteNoise.kr(mul, add), Dust.kr(sampleFreq)).lag(lag)
-        });
-
-        var voices = (1..voiceCount).collect({ |index|
-          Pan2.ar(
-            CombN.ar(
-              LFPulse.ar(
-                rand.(0.2, noteDetune, baseNote, 2).midicps * index,
-                0,
-                rand.(0.5, 0.5, 0.5)
-              ),
-              1,
-              rand.(0.3, noteDetune, baseNote, 5).midicps.reciprocal * rand.(0.2, 3, 4).round.lag(5),
-              rand.(0.2, 10, 0, 3)
-            ).tanh,
-            rand.(0.4, 1, 0, 2),
-            rand.(0.1, maxAmp)
-          )
-        });
-        Out.ar(out, LeakDC.ar(Mix.ar(voices)));
-      },
+      "Mt. Lion" -> , */
     ];
   
     context.server.sync;

--- a/engine/Engine_Dronecaster.sc
+++ b/engine/Engine_Dronecaster.sc
@@ -1,5 +1,6 @@
  Engine_Dronecaster : CroneEngine {
   var <synth;
+  var drones;
   // var <in;
 
   *new { arg context, doneCallback;
@@ -7,100 +8,104 @@
   }
 
   alloc {
-  
+
     // SynthDef(\InJacks, {
     //   arg out;
     //   var sig_;
     //   sig_ = SoundIn.ar([0,1]);
     //   Out.ar(out, sig_);
     // }).add;
-  
-    // The TestSine. Old faithful.
-    SynthDef(\Sine, {
-      arg out, hz=440, amp=0.02, amplag=0.02, hzlag=0.01;
-      var amp_, hz_;
-      amp_ = Lag.ar(K2A.ar(amp), amplag);
-      hz_ = Lag.ar(K2A.ar(hz), hzlag);
-      Out.ar(out, (SinOsc.ar(hz_) * amp_).dup);
-    }).add;
 
-    // @license
-    // Thee rusted satellites gather + sing.
-    SynthDef(\Zion, {
-      arg out, hz=55.1, amp=0.02, amplag=0.02, hzlag=0.01;
-      var amp_ = Lag.ar(K2A.ar(amp), amplag);
-      var hz_ = Lag.ar(K2A.ar(hz), hzlag);
-      var voiceCount = 5;
-      var baseNote = hz_.cpsmidi.round;
-      var noteDetune = (baseNote - hz_.cpsmidi).abs;
-      var maxAmp = amp_ / voiceCount;
-      
-      var rand = ({|sampleFreq=1, mul=1, add=0, lag=0.5|
-        Latch.ar(WhiteNoise.ar(mul, add), Dust.ar(sampleFreq)).lag(lag)
-      });
-      
-      var voices = (1..voiceCount).collect({ |index|
-        Pan2.ar(
-          Pulse.ar(
-            rand.(0.2, noteDetune, baseNote, 2).midicps * index,
-            rand.(0.5, 0.5, 1.5)
-          ),
-          rand.(0.3),
-          rand.(0.1, maxAmp)
-        );
-      });
-      Out.ar(out, Mix.ar(voices));
-    }).add;
-
-    // @cfdrake
-    SynthDef(\Supersaw, {
-      arg out, hz=440, amp=0.02, amplag=0.02, hzlag=0.01;
-      var amp_, hz_;
-      amp_ = Lag.ar(K2A.ar(amp), amplag);
-      hz_ = Lag.ar(K2A.ar(hz), hzlag);
-      Out.ar(out, Splay.ar(Array.fill(5, { |i|
-        BPF.ar(
-          Saw.ar(hz_ * i + SinOsc.kr(0.1 * i, 0, 0.5)),
-          100 + (i * 100) + SinOsc.kr(0.05 * i, mul: 100),
-          2
-        )
-      }), 1) * amp_);
-    }).add;
-    
-    // @license
-    // Roars through a twisting canyon.
-    SynthDef(\Lion, {
-      arg out, hz=55.1, amp=0.02, amplag=0.02, hzlag=0.01;
-      var amp_ = amp.lag(amplag);
-      var hz_ = hz.lag(hzlag);
-      var voiceCount = 9;
-      var baseNote = hz_.cpsmidi.round;
-      var noteDetune = (baseNote - hz_.cpsmidi).abs;
-      var maxAmp = amp_ / voiceCount;
-
-      var rand = ({|sampleFreq=1, mul=1, add=0, lag=0.5|
-        Latch.kr(WhiteNoise.kr(mul, add), Dust.kr(sampleFreq)).lag(lag)
-      });
-
-      var voices = (1..voiceCount).collect({ |index|
-        Pan2.ar(
-          CombN.ar(
-            LFPulse.ar(
+    // TODO: Lookup by string (name).
+    // Meanwhile, order below *must* match drones var in Lua!
+    drones = [
+      // @license
+      // Thee rusted satellites gather + sing.
+      "Mt. Zion" -> {
+        arg out, hz=55.1, amp=0.02, amplag=0.02, hzlag=0.01;
+        var amp_ = Lag.ar(K2A.ar(amp), amplag);
+        var hz_ = Lag.ar(K2A.ar(hz), hzlag);
+        var voiceCount = 5;
+        var baseNote = hz_.cpsmidi.round;
+        var noteDetune = (baseNote - hz_.cpsmidi).abs;
+        var maxAmp = amp_ / voiceCount;
+        
+        var rand = ({|sampleFreq=1, mul=1, add=0, lag=0.5|
+          Latch.ar(WhiteNoise.ar(mul, add), Dust.ar(sampleFreq)).lag(lag)
+        });
+        
+        var voices = (1..voiceCount).collect({ |index|
+          Pan2.ar(
+            Pulse.ar(
               rand.(0.2, noteDetune, baseNote, 2).midicps * index,
-              0,
-              rand.(0.5, 0.5, 0.5)
+              rand.(0.5, 0.5, 1.5)
             ),
-            1,
-            rand.(0.3, noteDetune, baseNote, 5).midicps.reciprocal * rand.(0.2, 3, 4).round.lag(5),
-            rand.(0.2, 10, 0, 3)
-          ).tanh,
-          rand.(0.4, 1, 0, 2),
-          rand.(0.1, maxAmp)
-        )
-      });
-      Out.ar(out, LeakDC.ar(Mix.ar(voices)));
-    }).add;
+            rand.(0.3),
+            rand.(0.1, maxAmp)
+          );
+        });
+        Out.ar(out, Mix.ar(voices));
+      },
 
+      // The TestSine. Old faithful.
+      "Sine" -> {
+        arg out, hz=440, amp=0.02, amplag=0.02, hzlag=0.01;
+        var amp_, hz_;
+        amp_ = Lag.ar(K2A.ar(amp), amplag);
+        hz_ = Lag.ar(K2A.ar(hz), hzlag);
+        Out.ar(out, (SinOsc.ar(hz_) * amp_).dup);
+      }, 
+
+      // @cfdrake
+      "Supersaw" -> {
+        arg out, hz=440, amp=0.02, amplag=0.02, hzlag=0.01;
+        var amp_, hz_;
+        amp_ = Lag.ar(K2A.ar(amp), amplag);
+        hz_ = Lag.ar(K2A.ar(hz), hzlag);
+        Out.ar(out, Splay.ar(Array.fill(5, { |i|
+          BPF.ar(
+            Saw.ar(hz_ * i + SinOsc.kr(0.1 * i, 0, 0.5)),
+            100 + (i * 100) + SinOsc.kr(0.05 * i, mul: 100),
+            2
+          )
+        }), 1) * amp_);
+      }, 
+
+      // @license
+      // Roars through a twisting canyon.
+      "Mt. Lion" -> {
+        arg out, hz=55.1, amp=0.02, amplag=0.02, hzlag=0.01;
+        var amp_ = amp.lag(amplag);
+        var hz_ = hz.lag(hzlag);
+        var voiceCount = 9;
+        var baseNote = hz_.cpsmidi.round;
+        var noteDetune = (baseNote - hz_.cpsmidi).abs;
+        var maxAmp = amp_ / voiceCount;
+
+        var rand = ({|sampleFreq=1, mul=1, add=0, lag=0.5|
+          Latch.kr(WhiteNoise.kr(mul, add), Dust.kr(sampleFreq)).lag(lag)
+        });
+
+        var voices = (1..voiceCount).collect({ |index|
+          Pan2.ar(
+            CombN.ar(
+              LFPulse.ar(
+                rand.(0.2, noteDetune, baseNote, 2).midicps * index,
+                0,
+                rand.(0.5, 0.5, 0.5)
+              ),
+              1,
+              rand.(0.3, noteDetune, baseNote, 5).midicps.reciprocal * rand.(0.2, 3, 4).round.lag(5),
+              rand.(0.2, 10, 0, 3)
+            ).tanh,
+            rand.(0.4, 1, 0, 2),
+            rand.(0.1, maxAmp)
+          )
+        });
+        Out.ar(out, LeakDC.ar(Mix.ar(voices)));
+      },
+    ];
+  
     context.server.sync;
     
     // synth = Synth.new(\Sine, [\out, context.out_b], context.xg);
@@ -119,20 +124,12 @@
         synth.free;
     });
     
-    this.addCommand("start_sine", "i", { arg msg;
-      synth = Synth.new(\Sine, [\out, context.out_b], context.xg);
-    });
+    this.addCommand("start_drone", "i", { arg msg; 
+      if (synth != nil, { synth.free });  // Unload any playing synth
 
-    this.addCommand("start_zion", "i", { arg msg;
-      synth = Synth.new(\Zion, [\out, context.out_b], context.xg);
-    });
-
-    this.addCommand("start_lion", "i", { arg msg;
-      synth = Synth.new(\Lion, [\out, context.out_b], context.xg);
-    });
-    
-    this.addCommand("start_supersaw", "i", { arg msg;
-      synth = Synth.new(\Supersaw, [\out, context.out_b], context.xg);
+      if (msg[1] < drones.size, {
+        synth = drones[msg[1]].value.play(context.xg, context.out_b);
+      });
     });
     
     // this.addCommand("injack", "s", { arg msg;

--- a/engine/Engine_Dronecaster.sc
+++ b/engine/Engine_Dronecaster.sc
@@ -1,7 +1,7 @@
  Engine_Dronecaster : CroneEngine {
   var <synth;
   var drones;
-  var hz, amp;
+  var hz = 55, amp = 0.4;
   // var <in;
 
   *new { arg context, doneCallback;
@@ -34,22 +34,14 @@
     // synth = Synth.new(\Zion, [\out, context.out_b], context.xg);
     // in = Synth.new(\InJacks, [\out, context.out_a], context.xg);
     
-    this.addCommand("send_list", "i", {
-      drones.keysDo({|name| 
-        ("sending name: " ++ name).postln;
-        luaOsc.sendMsg("/add_drone", name);
-      });
-      luaOsc.sendMsg("/sent_all") ;
-    });
-
     this.addCommand("hz", "f", { arg msg;
       hz = msg[1];
-      synth.set(\hz, hz);
+      if (synth != nil, { synth.set(\hz, hz) });
     });
     
     this.addCommand("amp", "f", { arg msg;
       amp = msg[1];
-      synth.set(\amp, amp);
+      if (synth != nil, { synth.set(\amp, amp) });
     });
     
     this.addCommand("stop", "i", { arg msg;
@@ -57,14 +49,15 @@
     });
     
     this.addCommand("start", "s", { arg msg; 
-      var drone;
+      var drone, droneName;
 
       if (synth != nil, { synth.free });  // Unload any playing synth
-
-      drone = drones[msg[1].asString];
+      droneName = msg[1].asString;
+      droneName.postln;
+      drone = drones[droneName];
 
       if (drone != nil, {
-        synth = drone.play(context.xg, context.out_b, [\hz, hz, \amp, amp]);
+        synth = drone.play(context.xg, context.out_b, args: [hz: hz, amp: amp]);
       });
     });
     

--- a/engine/Engine_Dronecaster.sc
+++ b/engine/Engine_Dronecaster.sc
@@ -28,8 +28,6 @@
     //   Out.ar(out, sig_);
     // }).add;
 
-    // TODO: Lookup by string (name).
-  
     context.server.sync;
     
     // synth = Synth.new(\Sine, [\out, context.out_b], context.xg);

--- a/engine/Engine_Dronecaster.sc
+++ b/engine/Engine_Dronecaster.sc
@@ -1,6 +1,7 @@
  Engine_Dronecaster : CroneEngine {
-  var <synth;
+  var synth;
   var drones;
+  var droneGroup;
   var hz = 55, amp = 0.4;
   // var <in;
 
@@ -11,6 +12,8 @@
   alloc {
     var baseDronePath = "/home/we/dust/code/dronecaster/engine/drones";
     var luaOsc = NetAddr("localhost", 10111);
+
+    droneGroup = Group.new(context.xg);
 
     drones = PathName.new(baseDronePath).entries.collect({|e| 
       var name = e.fileNameWithoutExtension;
@@ -45,19 +48,19 @@
     });
     
     this.addCommand("stop", "i", { arg msg;
-        synth.free;
+        droneGroup.freeAll;
     });
     
     this.addCommand("start", "s", { arg msg; 
       var drone, droneName;
 
-      if (synth != nil, { synth.free });  // Unload any playing synth
+      droneGroup.freeAll; // Unload any playing synth
       droneName = msg[1].asString;
       droneName.postln;
       drone = drones[droneName];
 
       if (drone != nil, {
-        synth = drone.play(context.xg, context.out_b, args: [hz: hz, amp: amp]);
+        synth = drone.play(droneGroup, context.out_b, args: [hz: hz, amp: amp]);
       });
     });
     
@@ -68,7 +71,7 @@
   }
 
   free {
-    synth.free;
+    droneGroup.freeAll;
   }
   
 }

--- a/engine/drones/Mt. Lion.scd
+++ b/engine/drones/Mt. Lion.scd
@@ -1,0 +1,33 @@
+// @license
+// Roars through a twisting canyon.
+{
+    arg out, hz=55.1, amp=0.02, amplag=0.02, hzlag=0.01;
+    var amp_ = amp.lag(amplag);
+    var hz_ = hz.lag(hzlag);
+    var voiceCount = 9;
+    var baseNote = hz_.cpsmidi.round;
+    var noteDetune = (baseNote - hz_.cpsmidi).abs;
+    var maxAmp = amp_ / voiceCount;
+
+    var rand = ({|sampleFreq=1, mul=1, add=0, lag=0.5|
+        Latch.kr(WhiteNoise.kr(mul, add), Dust.kr(sampleFreq)).lag(lag)
+    });
+
+    var voices = (1..voiceCount).collect({ |index|
+        Pan2.ar(
+        CombN.ar(
+            LFPulse.ar(
+            rand.(0.2, noteDetune, baseNote, 2).midicps * index,
+            0,
+            rand.(0.5, 0.5, 0.5)
+            ),
+            1,
+            rand.(0.3, noteDetune, baseNote, 5).midicps.reciprocal * rand.(0.2, 3, 4).round.lag(5),
+            rand.(0.2, 10, 0, 3)
+        ).tanh,
+        rand.(0.4, 1, 0, 2),
+        rand.(0.1, maxAmp)
+        )
+    });
+    Out.ar(out, LeakDC.ar(Mix.ar(voices)));
+}

--- a/engine/drones/Mt. Zion.scd
+++ b/engine/drones/Mt. Zion.scd
@@ -1,0 +1,27 @@
+// @license
+// Thee rusted satellites gather + sing.
+{
+    arg out, hz=55.1, amp=0.02, amplag=0.02, hzlag=0.01;
+    var amp_ = Lag.ar(K2A.ar(amp), amplag);
+    var hz_ = Lag.ar(K2A.ar(hz), hzlag);
+    var voiceCount = 5;
+    var baseNote = hz_.cpsmidi.round;
+    var noteDetune = (baseNote - hz_.cpsmidi).abs;
+    var maxAmp = amp_ / voiceCount;
+    
+    var rand = ({|sampleFreq=1, mul=1, add=0, lag=0.5|
+        Latch.ar(WhiteNoise.ar(mul, add), Dust.ar(sampleFreq)).lag(lag)
+    });
+    
+    var voices = (1..voiceCount).collect({ |index|
+        Pan2.ar(
+        Pulse.ar(
+            rand.(0.2, noteDetune, baseNote, 2).midicps * index,
+            rand.(0.5, 0.5, 1.5)
+        ),
+        rand.(0.3),
+        rand.(0.1, maxAmp)
+        );
+    });
+    Out.ar(out, Mix.ar(voices));
+}

--- a/engine/drones/Sine.scd
+++ b/engine/drones/Sine.scd
@@ -1,0 +1,8 @@
+// The TestSine. Old faithful.
+{
+    arg out, hz=440, amp=0.02, amplag=0.02, hzlag=0.01;
+    var amp_, hz_;
+    amp_ = Lag.ar(K2A.ar(amp), amplag);
+    hz_ = Lag.ar(K2A.ar(hz), hzlag);
+    Out.ar(out, (SinOsc.ar(hz_) * amp_).dup);
+}

--- a/engine/drones/Supersaw.scd
+++ b/engine/drones/Supersaw.scd
@@ -1,0 +1,14 @@
+// @cfdrake
+{
+    arg out, hz=440, amp=0.02, amplag=0.02, hzlag=0.01;
+    var amp_, hz_;
+    amp_ = Lag.ar(K2A.ar(amp), amplag);
+    hz_ = Lag.ar(K2A.ar(hz), hzlag);
+    Out.ar(out, Splay.ar(Array.fill(5, { |i|
+        BPF.ar(
+        Saw.ar(hz_ * i + SinOsc.kr(0.1 * i, 0, 0.5)),
+        100 + (i * 100) + SinOsc.kr(0.05 * i, mul: 100),
+        2
+        )
+    }), 1) * amp_);
+}

--- a/lib/draw.lua
+++ b/lib/draw.lua
@@ -65,11 +65,11 @@ function draw.top_menu(d, h, a)
   draw.mlrs(88, 12, 40, 0)
   screen.level(screen_levels["h"])
   screen.move(2, 8)
-  screen.text(d)
+  screen.text(d or "")
   screen.move(45, 8)
-  screen.text(h)
+  screen.text(h or "")
   screen.move(89, 8)
-  screen.text(a)
+  screen.text(a or "")
 end
 
 


### PR DESCRIPTION
Refactor drone selection - no more hard-coded tables, just look up the drones from the `engine/drones` directory!

Special bonuses:
- Parameters now maintained consistently between drone selections.
- Drones are assigned to and freed by group, so they no longer get into nasty overlapsville. Flip to your heart's content!
- Looking up by directory should mean that reloading the engine also refreshes the list of drones, so you can add your own without having to restart SC/norns!
- Handles a small handful of errors slightly better.