### PR TITLE
Add recording

### DIFF
--- a/dronecaster.lua
+++ b/dronecaster.lua
@@ -37,8 +37,8 @@ playing_frame = 1
 recording_frame = 1
 messages = {}
 messages["empty"] = "..."
-messages["start_recording"] = "Recording broken..."
-messages["stop_recording"] = "...still broken."
+messages["start_recording"] = "Recording..."
+messages["stop_recording"] = "...recording stopped."
 messages["start_casting"] = "Casting drone..."
 messages["stop_casting"] = "Cast halted."
 alert = {}
@@ -128,12 +128,14 @@ function key(n, z)
     alert["recording"] = true
     alert["recording_frame"] = 1
     if recording == true then
+      local record_path = make_filename()
       recording_time = 0
       alert["recording_message"] = messages["start_recording"]
-      -- engine.record_start()
+      print("recording to file " .. record_path)
+      engine.record_start(record_path)
     else
       alert["recording_message"] = messages["stop_recording"]
-      -- engine.record_stop(make_filename())
+      engine.record_stop(1)
     end
   elseif n == 3 and z == 1 then
     playing = not playing

--- a/dronecaster.lua
+++ b/dronecaster.lua
@@ -12,6 +12,10 @@
 -- "Supersaw" by @cfd90
 -- "Mt. Lion" by @license
 -- ........................................
+-- borrowings:
+-- - levels/effects parameter setting from 
+--   https://github.com/21echoes/pedalboard
+-- ........................................
 -- l.llllllll.co/dronecaster
 -- <3 @tyleretters
 -- v0.0.2 ALPHA
@@ -23,6 +27,9 @@ draw = include "lib/draw"
 
 -- variables
 --------------------------------------------------------------------------------
+local initital_monitor_level
+local initital_reverb_onoff
+
 filename_prefix = "dronecaster_"
 save_path = _path.audio .. "dronecaster/"
 amp_default = .4
@@ -53,6 +60,12 @@ alert["recording_frame"] = 0
 --------------------------------------------------------------------------------
 function init()
   audio:pitch_off()
+
+  initital_monitor_level = params:get('monitor_level')
+  params:set('monitor_level', -math.huge)
+  initital_reverb_onoff = params:get('reverb')
+  params:set('reverb', 1) -- 1 is OFF
+
   draw.init()
   if util.file_exists(save_path) == false then
     util.make_dir(save_path)
@@ -179,6 +192,12 @@ function osc_in(path, msg)
     print("adding drone" .. msg[1])
     table.insert(drones, msg[1])
   end
+end
+
+function cleanup()
+  -- Put user's audio settings back where they were
+  params:set('monitor_level', initital_monitor_level)
+  params:set('reverb', initital_reverb_onoff)
 end
 
 osc.event = osc_in -- should probably go in init? race conditions tho?


### PR DESCRIPTION
We live in an imperfect world where the output of the norns headphone outs appears to be the same as that of the line outputs. So, here's the version of recording that perhaps makes the most sense in that world: recording the line inputs to disk while continuing to output the dry signal.

The monitor level is automatically muted, thanks to code borrowed from (and attributed to) the pedalboard app by 21echoes. This prevents feedback without having to frantically jump to the levels screen. The reverb is also turned off. The user settings prior to loading dronecaster are restored on teardown of the app.