### PR TITLE
Revert reference to `this` in arg init

### DIFF
--- a/engine/Engine_Dronecaster.sc
+++ b/engine/Engine_Dronecaster.sc
@@ -34,7 +34,7 @@ Dronecaster {
 		if (drones.keys.includes(name), {
 			postln('setting drone: '++name);
 			socket.setSource({
-			    arg hz=this.hz, amp=this.amp, amplag=0.02, hzlag=0.01;
+			    arg hz=440, amp=0.02, amplag=0.02, hzlag=0.01;
 			    var amp_, hz_;
 			    amp_ = Lag.ar(K2A.ar(amp), amplag);
 			    hz_ = Lag.ar(K2A.ar(hz), hzlag);


### PR DESCRIPTION
This seems to reconcile the conflict between the recent additions by @schollz  and @catfact  I have no idea why, though.