### PR TITLE
Cleanup engine

### DIFF
--- a/dronecaster.lua
+++ b/dronecaster.lua
@@ -11,6 +11,8 @@
 --------------------------------------------------------------------------------
 engine.name = "Dronecaster"
 draw = include "lib/draw"
+include "lib/util"
+
 local MusicUtil=require "musicutil"
 
 -- variables
@@ -50,191 +52,220 @@ alert["recording_message"] = messages["empty"]
 alert["recording"] = false
 alert["recording_frame"] = 0
 
+done_init = false
+
 -- init & core
 --------------------------------------------------------------------------------
 function init()
-  audio:pitch_off()
 
-  initital_monitor_level = params:get('monitor_level')
-  params:set('monitor_level', -math.huge)
-  initital_reverb_onoff = params:get('reverb')
-  params:set('reverb', 1) -- 1 is OFF
+   list_drone_names(
+      function(names)
+	 drones = names
+	 tab.print(drones)
+	 
+	 audio:pitch_off()
 
-  draw.init()
-  if util.file_exists(save_path) == false then
-    util.make_dir(save_path)
-  end
-  
-  crow.input[1].mode("stream", .01)
-  crow.input[1].stream = process_crow_cv_a
-  
-  counter.time = 1
-  counter.count = -1
-  counter.play = 1
-  counter.event = the_sands_of_time
-  counter:start()
-  params:add_control("amp", "amp", controlspec.new(0, 1, "amp", 0, amp_default, "amp"))
-  params:set_action("amp", engine.amp)
-  params:add_control("hz", "hz", controlspec.new(0, 20000, "lin", 0, hz_default, "hz"))
-  -- params:set_action("hz", engine.hz)
-  params:set_action("hz", hz_base_update)
-  params:add{type="number",id="note",name="note",min=0,max=127,default=24,formatter=function(param) return MusicUtil.note_num_to_name(param:get(),true) end}
-  params:set_action("note",function(v)
-    params:set("hz",math.pow(2,(v-69)/12)*440)
-  end)
-  params:add_control("drone","drone",controlspec.new(1, #drones, "lin", 0, drone_default, "drone",1/(#drones-1)))
-  params:set_action("drone", play_drone)
-  engine.amp(amp_default)
-  engine.hz(hz_default)
+	 initital_monitor_level = params:get('monitor_level')
+	 params:set('monitor_level', -math.huge)
+	 initital_reverb_onoff = params:get('reverb')
+	 params:set('reverb', 1) -- 1 is OFF
+
+	 draw.init()
+	 if util.file_exists(save_path) == false then
+	    util.make_dir(save_path)
+	 end
+	 
+	 crow.input[1].mode("stream", .01)
+	 crow.input[1].stream = process_crow_cv_a
+	 
+	 counter.time = 1
+	 counter.count = -1
+	 counter.play = 1
+	 counter.event = the_sands_of_time
+	 counter:start()
+	 params:add_control("amp", "amp", controlspec.new(0, 1, "amp", 0, amp_default, "amp"))
+	 params:set_action("amp", engine.amp)
+	 params:add_control("hz", "hz", controlspec.new(0, 20000, "lin", 0, hz_default, "hz"))
+	 params:set_action("hz", hz_base_update)
+	 params:add{type="number",id="note",name="note",min=0,max=127,default=24,formatter=function(param) return MusicUtil.note_num_to_name(param:get(),true) end}
+	 params:set_action("note",function(v)
+			      params:set("hz",math.pow(2,(v-69)/12)*440)
+	 end)
+
+	 --params:add_control("drone","drone", controlspec.new(1, #drones, "lin", 0, drone_default, "drone", 1/(#drones-1)))
+	 params:add_option("drone", "drone", drones)
+	 params:set_action("drone", play_drone)
+	 engine.amp(amp_default)
+	 engine.hz(hz_default)
+	 
+	 done_init = true
+      end
+   )
 end
 
 function the_sands_of_time()
-  if playing then
-    playing_frame = playing_frame + 1  
-  end
-  if recording then
-    recording_frame = recording_frame + 1
-    recording_time = recording_time + 1
-  end
-  redraw()
+   if playing then
+      playing_frame = playing_frame + 1  
+   end
+   if recording then
+      recording_frame = recording_frame + 1
+      recording_time = recording_time + 1
+   end
+   redraw()
 end
 
 function redraw()
-  screen.clear()
-  screen.aa(0)
-  screen.font_face(0)
-  screen.font_size(8)
-  pf = playing_frame
-  rf = recording_time
-  d = drones[round(params:get("drone"))]
-  h = round(params:get("hz")) .. " hz"
-  a = round(params:get("amp"), 2) .. " amp"
-  hud = d .. " " .. h .. " " .. a
-  p = playing
-  draw.birds(pf)
-  draw.wind(pf)
-  draw.lights(pf)
-  draw.uap(pf)
-  draw.landscape()
-  draw.top_menu(hud)
-  draw.clock(rf)
-  draw.play_stop(p)
-  if (alert["recording"]) then
-    alert = draw.alert_recording(alert, messages)
-  end
-  if (alert["casting"]) then
-    alert = draw.alert_casting(alert, messages)
-  end
-  screen.update()
+   if (not done_init) then return end
+   screen.clear()
+   screen.aa(0)
+   screen.font_face(0)
+   screen.font_size(8)
+   pf = playing_frame
+   rf = recording_time
+   d = drones[round(params:get("drone"))]
+   h = round(params:get("hz")) .. " hz"
+   a = round(params:get("amp"), 2) .. " amp"
+   hud = d .. " " .. h .. " " .. a
+   p = playing
+   draw.birds(pf)
+   draw.wind(pf)
+   draw.lights(pf)
+   draw.uap(pf)
+   draw.landscape()
+   draw.top_menu(hud)
+   draw.clock(rf)
+   draw.play_stop(p)
+   if (alert["recording"]) then
+      alert = draw.alert_recording(alert, messages)
+   end
+   if (alert["casting"]) then
+      alert = draw.alert_casting(alert, messages)
+   end
+   screen.update()
 end
 
 -- encs & keys
 --------------------------------------------------------------------------------
 function enc(n,d)
-  local mult
-  if n == 1 then
-    params:set("drone", util.clamp(params:get("drone") + d, 1, #drones))
-  elseif n == 2 then
-    mult = alt and .1 or .001
-    params:delta("hz", d * mult)
-  elseif n == 3 then
-    mult = alt and 10 or .1
-    params:delta("amp", d * mult)
-  end
-  redraw()
+   local mult
+   if n == 1 then
+      params:set("drone", util.clamp(params:get("drone") + d, 1, #drones))
+   elseif n == 2 then
+      mult = alt and .1 or .001
+      params:delta("hz", d * mult)
+   elseif n == 3 then
+      mult = alt and 10 or .1
+      params:delta("amp", d * mult)
+   end
+   redraw()
 end
 
 function key(n, z)
-  if n == 1 and z == 1 then
+   if n == 1 and z == 1 then
       alt = true
-  elseif z == 0 then
-    if n == 1 then
-      alt = false
-    end
-    if n == 2 then
-      recording = not recording
-      alert["recording"] = true
-      alert["recording_frame"] = 1
-      if recording == true then
-        local record_path = make_filename()
-        recording_time = 0
-        alert["recording_message"] = messages["start_recording"]
-        print("recording to file " .. record_path)
-        engine.record_start(record_path)
-      else
-        alert["recording_message"] = messages["stop_recording"]
-        engine.record_stop(1)
+   elseif z == 0 then
+      if n == 1 then
+	 alt = false
       end
-    elseif n == 3 then
-      playing = not playing
-      alert["casting"] = true
-      alert["casting_frame"] = 1
-      if playing == true then
-        play_drone()
-        alert["casting_message"] = messages["start_casting"]
-      else
-        engine.stop(1)
-        alert["casting_message"] = messages["stop_casting"]
+      if n == 2 then
+	 recording = not recording
+	 alert["recording"] = true
+	 alert["recording_frame"] = 1
+	 if recording == true then
+	    local record_path = make_filename()
+	    recording_time = 0
+	    alert["recording_message"] = messages["start_recording"]
+	    print("recording to file " .. record_path)
+	    engine.record_start(record_path)
+	 else
+	    alert["recording_message"] = messages["stop_recording"]
+	    engine.record_stop(1)
+	 end
+      elseif n == 3 then
+	 playing = not playing
+	 alert["casting"] = true
+	 alert["casting_frame"] = 1
+	 if playing == true then
+	    play_drone()
+	    alert["casting_message"] = messages["start_casting"]
+	 else
+	    engine.stop(1)
+	    alert["casting_message"] = messages["stop_casting"]
+	 end
       end
-    end
-  end
-  redraw()
+   end
+   redraw()
 end
 
 function play_drone()
-    local droneIndex = params:get("drone")
-    playing = true
-    if droneIndex > 0 and droneIndex <= #drones then
+   local droneIndex = params:get("drone")
+   playing = true
+   if droneIndex > 0 and droneIndex <= #drones then
       engine.start(drones[droneIndex])
-    end
+   end
 end
 
 -- utils
 --------------------------------------------------------------------------------
 function make_filename()
-  return save_path .. filename_prefix .. os.date("%Y_%m_%d_%H_%M_%S") .. ".aiff"
+   return save_path .. filename_prefix .. os.date("%Y_%m_%d_%H_%M_%S") .. ".aiff"
 end
 
 function round(num, places)
-  if places and places > 0 then
-    mult = 10 ^ places
-    return math.floor(num * mult + 0.5) / mult
-  end
-  return math.floor(num + 0.5)
+   if places and places > 0 then
+      mult = 10 ^ places
+      return math.floor(num * mult + 0.5) / mult
+   end
+   return math.floor(num + 0.5)
 end
 
-function osc_in(path, msg)
-  if path == "/add_drone" then
-    print("adding drone" .. msg[1])
-    table.insert(drones, msg[1])
-  end
-  table.sort(drones)
-end
+--[[
+   function osc_in(path, msg)
+   if path == "/add_drone" then
+   print("adding drone: " .. msg[1])
+   table.insert(drones, msg[1])
+   end
+   table.sort(drones)
+   end
+--]]
 
 function cleanup()
-  -- Put user's audio settings back where they were
-  params:set('monitor_level', initital_monitor_level)
-  params:set('reverb', initital_reverb_onoff)
-  engine.stop(1)
-  engine.record_stop(1)
+   -- Put user's audio settings back where they were
+   params:set('monitor_level', initital_monitor_level)
+   params:set('reverb', initital_reverb_onoff)
+   engine.stop(1)
+   engine.record_stop(1)
 end
 
 function hz_base_update(n)
-  hz_base = n
-  engine.hz(hz_base * crow_cv)
+   hz_base = n
+   engine.hz(hz_base * crow_cv)
 end
 
 function process_crow_cv_a(v)
-  -- print("input stream: "..v)
-  -- print(v)
-  crow_cv = 2 ^ ((v + 1) - 1)
-  engine.hz(hz_base * crow_cv)
+   -- print("input stream: "..v)
+   -- print(v)
+   crow_cv = 2 ^ ((v + 1) - 1)
+   engine.hz(hz_base * crow_cv)
 end
 
 function rerun()
-  norns.script.load(norns.state.script)
+   norns.script.load(norns.state.script)
 end
 
 function r() rerun() end
 
-osc.event = osc_in -- should probably go in init? race conditions tho?
+function list_drone_names(callback)
+   local cb = function(text)
+      local names = {}
+      for line in string.gmatch(text, "/[%a%d%.%s]-%.scd") do
+	 name = string.sub(line, 2, -5)
+	 table.insert(names, name)
+      end
+      table.sort(names)
+      callback(names)
+   end
+   norns.system_cmd('find '.. _path.code .. 'dronecaster/engine/drones -name *.scd', cb)
+end
+
+--osc.event = osc_in -- should probably go in init? race conditions tho?

--- a/dronecaster.lua
+++ b/dronecaster.lua
@@ -11,7 +11,6 @@
 --------------------------------------------------------------------------------
 engine.name = "Dronecaster"
 draw = include "lib/draw"
-include "lib/util"
 
 local MusicUtil=require "musicutil"
 

--- a/engine/Dronecaster_SynthSocket.sc
+++ b/engine/Dronecaster_SynthSocket.sc
@@ -14,10 +14,8 @@ DroneCaster_SynthSocket {
 		arg fn, name;
 		var def, nope = false;
 		postln("building synthdef: "++name);
-		//		postln("fn = " ++ fn);
-		//		postln("class(fn) = " ++ fn.class);
 		def = SynthDef.new(name, {
-			arg hz, amp=1, out=0, gate=1, attack=1, release=1;
+			arg hz, amp=1, out=0, gate=1, attack=4.0, release=4.0;
 
 			var aenv, snd;
 			snd = { fn.value(K2A.ar(hz), K2A.ar(amp)) }.try { 
@@ -27,7 +25,7 @@ DroneCaster_SynthSocket {
 				nope = true;
 				[Silent.ar]
 			};
-			aenv = EnvGen.kr(Env.asr(gate), attack, 1, release);
+			aenv = EnvGen.kr(Env.asr(attack, 1, release), gate, doneAction:2);
 			// force mix down to stereo (interleaved)
 			snd = Mix.new(snd.flatten.clump(2)) * aenv;
 			
@@ -49,16 +47,20 @@ DroneCaster_SynthSocket {
 	}
 
 	setSource { arg def;
+		postf("socket requested new source: %; current synth = %\n", def.name, synth);
 		cuedSource = def;
 		if (synth.isNil, {
+			postln("no current synth; playing now");
 			this.performSource;
 		}, {
-			this.stop;
+			postln("stopping current synth...");
+			synth.set(\gate, 0);
 		});
 	}
 
 
 	setControl { arg k, v;
+		//postf("setting control % = %\n", k, v);
 		controls[k].set(v);
 	}
 
@@ -67,6 +69,7 @@ DroneCaster_SynthSocket {
 		out = aOut;
 		controls = Dictionary.new;
 		aControls.do({ arg k;
+			postln("creating control bus: " ++ k);
 			controls[k] = Bus.control(server, 1);
 		});
 
@@ -77,7 +80,9 @@ DroneCaster_SynthSocket {
 		doneResponder =  OSCFunc({ arg msg;
 			var nodeId, id;
 			nodeId = msg[1];
+			postln("handling node end for ID: " ++ nodeId);
 			if (synth.notNil, {
+				postln("(our synth ID: " ++ synth.nodeID ++ ")");
 				if (nodeId == synth.nodeID, {
 					this.performSource;
 				});
@@ -88,198 +93,33 @@ DroneCaster_SynthSocket {
 	free {
 		controls.do({ arg bus; bus.free; });
 		if (synth.notNil, { synth.free; });
+		group.free;
 	}
 
 	///// private
 
 	performSource {
-
+		postln(controls);		
 		if (cuedSource.notNil, {
-			// all this faff is just to initialize the synthdef with the values from the ctl busses.
-			// there is probably a cleaner way.
 			var controlVals = Dictionary.new;
-			var condition = Condition.new(false);
-			controls.do({ arg k, bus;
-				bus.get({ arg val;
-					controlVals[k] = val;
-					condition.test = true;
-					condition.signal;
-				});
-				condition.wait;
-			});
+			var condition = Condition.new;
+			var synthArgs = Dictionary.new;
 
-			synth = Synth.new(cuedSource, [\out, out] ++ controlVals.getPairs, target:group);
-			controls.do({ arg k, bus; synth.map(k, bus); });
+			postf("performing cued source: % (%)\n", cuedSource, cuedSource.name);
+			controls.keys.do({ arg k;
+				controlVals[k] = controls[k].getSynchronous;
+			});
+			
+			synthArgs = [\out, out] ++ controlVals.getPairs;
+			postln("synthArgs = " ++ synthArgs);
+			postln("cuedSource = " ++ cuedSource);
+			
+			synth = Synth.new(cuedSource.name, synthArgs, target:group);
+			postf("new synth = %\n", synth);
+			controls.keys.do({ arg k; synth.map(k, controls[k]); });
 			cuedSource = nil;
 		}, {
-			// no cued source
 			synth = nil;
 		});
 	}
 }
-
-
-
-/*
-// a primitive and limited analog to `NodeProxy`,
-// which just crossfades between two stereo synth functions.
-// motivation is to limit the number of active synths during crossfades,
-// by specifying a shallow queuing behavior.
-// @zebra
-
-Dronecaster_SynthSocket {
-var server;          // a Server!
-var controls;        // Set of control names
-var <inBus;          // Array of 2 stereo Busses
-
-var group;           // a Group
-var <fadeSynth;      // synth to perform the xfade
-
-var <controlBus;     // Dictionary of control busses
-var <controlLag;     // Dictionary of control-rate lag synths
-
-var <source;         // synth-defining Function which is currently fading in or active
-var <sourceLast;     // the previously active source synth Function
-var <sourceQ;        // queued synth Function
-
-var <sourceIndex;    // current index of active source bus
-var <isFading;       // flag indicating xfade in progress
-
-var controlLagTime = 1.0;
-var fadeTime = 4.0;
-
-*new {
-arg server,      // instance of Server
-out,             // output bus index
-controls;        // array of control names; source synth functions should accept these args
-^super.new.init(server, out, controls);
-}
-
-init {
-arg s, out, ctl;
-
-server = s;
-controls = ctl.asSet;
-
-source = nil;
-sourceLast = nil;
-sourceQ = nil;
-
-sourceIndex = 0;
-isFading = false;
-
-group = Group.new(server);
-inBus = Array.fill(2, { Bus.audio(s, 2) });
-
-controlBus = Dictionary.new;
-controlLag = Dictionary.new;
-controls.do({ arg name;
-controlBus[name] = Bus.control(s);
-controlLag[name] = {
-arg bus, value, time = 1.0;
-ReplaceOut.kr(bus, Lag.kr(value, time));
-}.play(target:group, args:[\bus, controlBus[name].index]);
-});
-
-fadeSynth = Array.fill(2, { arg i;
-{
-arg out=0, in, gate, time=4;
-var fade, snd;
-fade = EnvGen.ar(Env.asr(time, 1, time), gate);
-snd = fade * In.ar(in, 2);
-Out.ar(out, snd)
-}.play(target:group, args: [
-\out, out,
-\in, inBus[i].index,
-\time, fadeTime
-]);
-});
-}
-
-setSource { arg newFunction;
-if (isFading, {
-sourceQ = newFunction;
-}, {
-this.performFade(newFunction);
-});
-}
-
-setFadeTime { arg time;
-fadeTime = time;
-fadeSynth.do({ arg synth; synth.set(\time, fadeTime); });
-}
-
-setControl { arg key, value;
-controlLag[key].set(\value, value);
-}
-
-setControlLagTime { arg time;
-controlLag.do({ arg synth; synth.set(\time, time); });
-}
-
-stop {
-fadeSynth.do({ arg synth; synth.set(\gate, 0); });
-}
-
-free {
-group.free;
-inBus.do({ arg bus; bus.free; });
-controlBus.do({ arg bus; bus.free; });
-}
-
-//////////////////////////////////////////
-/// private
-
-performFade { arg newFunction, args;
-sourceIndex = if (sourceIndex > 0, {0}, {1});
-// postln("performing fade; new source index = " ++ sourceIndex);
-
-isFading = true;
-
-// this Routine creates a new thread
-// not the most robust solution if fade times are extremely short,
-// but much simpler than synchronizing with events from the server.
-Routine {
-sourceLast = source;
-source = newFunction.play(
-outbus:inBus[sourceIndex].index,
-target:group,
-addAction:\addToHead // <- important
-);
-
-server.sync;
-
-controls.do({ arg key;
-source.map(key, controlBus[key]);
-});
-
-if ((args == nil).not, {
-controls.do({ arg key;
-if (args.includes(key), {
-controlBus[key].set(args[key]);
-})
-})
-});
-
-fadeSynth[sourceIndex].set(\gate, 1);
-fadeSynth[1-sourceIndex].set(\gate, 0);
-
-(fadeTime + 0.001).wait;
-this.finishFade;
-}.play;
-}
-
-finishFade {
-if ((sourceLast== nil).not, {
-sourceLast.free;
-});
-
-isFading = false;
-
-if ((sourceQ == nil).not, {
-this.performFade(sourceQ);
-sourceQ = nil;
-});
-}
-}
-*/

--- a/engine/Dronecaster_SynthSocket.sc
+++ b/engine/Dronecaster_SynthSocket.sc
@@ -15,7 +15,7 @@ DroneCaster_SynthSocket {
 		var def, nope = false;
 		postln("building synthdef: "++name);
 		def = SynthDef.new(name, {
-			arg hz, amp=1, out=0, gate=1, attack=4.0, release=4.0;
+			arg hz, amp=1, out=0, gate=1, attack=1.0, release=1.0;
 
 			var aenv, snd;
 			snd = { fn.value(K2A.ar(hz), K2A.ar(amp)) }.try { 
@@ -64,6 +64,14 @@ DroneCaster_SynthSocket {
 		controls[k].set(v);
 	}
 
+	setFadeTime { arg t;
+		fadeTime = t;
+		if (synth.notNil, {
+			synth.set(\atteck, fadeTime);
+			synth.set(\release, fadeTime);
+		});
+	}
+
 	init { arg aServer, aOut, aControls;
 		server = aServer;
 		out = aOut;
@@ -110,7 +118,7 @@ DroneCaster_SynthSocket {
 				controlVals[k] = controls[k].getSynchronous;
 			});
 			
-			synthArgs = [\out, out] ++ controlVals.getPairs;
+			synthArgs = [\out, out, \attack, fadeTime, \release, fadeTime] ++ controlVals.getPairs;
 			postln("synthArgs = " ++ synthArgs);
 			postln("cuedSource = " ++ cuedSource);
 			

--- a/engine/Dronecaster_SynthSocket.sc
+++ b/engine/Dronecaster_SynthSocket.sc
@@ -107,7 +107,6 @@ DroneCaster_SynthSocket {
 	///// private
 
 	performSource {
-		postln(controls);		
 		if (cuedSource.notNil, {
 			var controlVals = Dictionary.new;
 			var condition = Condition.new;
@@ -120,11 +119,12 @@ DroneCaster_SynthSocket {
 			
 			synthArgs = [\out, out, \attack, fadeTime, \release, fadeTime] ++ controlVals.getPairs;
 			postln("synthArgs = " ++ synthArgs);
-			postln("cuedSource = " ++ cuedSource);
+			postf("cuedSource = % (%)\n", cuedSource, cuedSource.name);
 			
 			synth = Synth.new(cuedSource.name, synthArgs, target:group);
-			postf("new synth = %\n", synth);
+			postf("new synth = %\n; mapping...\n", synth);
 			controls.keys.do({ arg k; synth.map(k, controls[k]); });
+			postln("...done; clearing cued source.");
 			cuedSource = nil;
 		}, {
 			synth = nil;

--- a/engine/Dronecaster_SynthSocket.sc
+++ b/engine/Dronecaster_SynthSocket.sc
@@ -1,3 +1,107 @@
+// old version way too complicated
+// we don't want xfades, we want down+up
+DroneCaster_SynthSocket {
+	var server, group, synth, controls, out;
+	var cuedSource, doneResponder;
+
+	*new {
+		arg server, out, controls;
+		^super.new.init(server, out, controls);
+	}
+
+	*wrapDef {
+		arg fn, name;
+		SynthDef.new(name, {
+			arg hz, amp=1, out=0, gate=1, attack=1, release=1;
+
+			var aenv, snd;
+			snd = fn.value;
+			aenv = EnvGen.kr(Env.asr(gate), attack, 1, release);
+			// force mix down to stereo (interleaved)
+			snd = Mix.new(fn.value.flatten.clump(2), mul:aenv);
+
+			Out.ar(out, snd);
+		})
+	}
+
+
+	stop {
+		if (synth.notNil, {
+			synth.set(\gate, 0);
+		});
+	}
+
+	setSource { arg def;
+		cuedSource = def;
+		if (synth.isNil, {
+			this.performSource;
+		}, {
+			this.stop;
+		});
+	}
+
+
+	setControl { arg k, v;
+		controls[k].set(v);
+	}
+
+	init { arg aServer, aOut, aControls;
+		server = aServer;
+		out = aOut;
+		controls = Dictionary.new;
+		aControls.do({ arg k;
+			controls[k] = Bus.control(server, 1);
+		});
+
+		group = Group.new(server);
+		synth = nil;
+		cuedSource = nil;
+
+		doneResponder =  OSCFunc({ arg msg;
+			var nodeId, id;
+			nodeId = msg[1];
+			if (synth.notNil && nodeId = synth.nodeID, {
+				this.performSource;
+			});
+		}, '/n_end', server.addr);
+	}
+
+	free {
+		controls.do({ arg bus; bus.free; });
+		if (synth.notNil, { synth.free; });
+	}
+
+	///// private
+
+	performSource {
+
+		if (cuedSource.notNil, {
+			// all this faff is just to initialize the synthdef with the values from the ctl busses.
+			// there is probably a cleaner way.
+			var controlVals = Dictionary.new;
+			var cond= Condition.new(false);
+			controls.do({ arg k, bus;
+				bus.get({ arg val;
+					controlVals[k] = val;
+					condition.test = true;
+					condition.signal;
+				});
+				condition.wait;
+			});
+
+			synth = Synth.new(cuedSource, [\out, out] ++ controlVals.getPairs, target:group);
+			controls.do({ arg k, bus; synth.map(k, bus); });
+			cuedSource = nil;
+		}. {
+			// no cued source
+			synth = nil;
+		});
+	}
+}
+
+
+
+/*
 // a primitive and limited analog to `NodeProxy`,
 // which just crossfades between two stereo synth functions.
 // motivation is to limit the number of active synths during crossfades,
@@ -5,157 +109,158 @@
 // @zebra
 
 Dronecaster_SynthSocket {
-	var server;          // a Server!
-	var controls;        // Set of control names
-	var <inBus;          // Array of 2 stereo Busses
+var server;          // a Server!
+var controls;        // Set of control names
+var <inBus;          // Array of 2 stereo Busses
 
-	var group;           // a Group
-	var <fadeSynth;      // synth to perform the xfade
+var group;           // a Group
+var <fadeSynth;      // synth to perform the xfade
 
-	var <controlBus;     // Dictionary of control busses
-	var <controlLag;     // Dictionary of control-rate lag synths
+var <controlBus;     // Dictionary of control busses
+var <controlLag;     // Dictionary of control-rate lag synths
 
-	var <source;         // synth-defining Function which is currently fading in or active
-	var <sourceLast;     // the previously active source synth Function
-	var <sourceQ;        // queued synth Function
+var <source;         // synth-defining Function which is currently fading in or active
+var <sourceLast;     // the previously active source synth Function
+var <sourceQ;        // queued synth Function
 
-	var <sourceIndex;    // current index of active source bus
-	var <isFading;       // flag indicating xfade in progress
+var <sourceIndex;    // current index of active source bus
+var <isFading;       // flag indicating xfade in progress
 
-	var controlLagTime = 1.0;
-	var fadeTime = 4.0;
+var controlLagTime = 1.0;
+var fadeTime = 4.0;
 
-	*new {
-		arg server,      // instance of Server
-		out,             // output bus index
-		controls;        // array of control names; source synth functions should accept these args
-		^super.new.init(server, out, controls);
-	}
-
-	init {
-		arg s, out, ctl;
-
-		server = s;
-		controls = ctl.asSet;
-
-		source = nil;
-		sourceLast = nil;
-		sourceQ = nil;
-
-		sourceIndex = 0;
-		isFading = false;
-
-		group = Group.new(server);
-		inBus = Array.fill(2, { Bus.audio(s, 2) });
-
-		controlBus = Dictionary.new;
-		controlLag = Dictionary.new;
-		controls.do({ arg name;
-			controlBus[name] = Bus.control(s);
-			controlLag[name] = {
-				arg bus, value, time = 1.0;
-				ReplaceOut.kr(bus, Lag.kr(value, time));
-			}.play(target:group, args:[\bus, controlBus[name].index]);
-		});
-
-		fadeSynth = Array.fill(2, { arg i;
-			{
-				arg out=0, in, gate, time=4;
-				var fade, snd;
-				fade = EnvGen.ar(Env.asr(time, 1, time), gate);
-				snd = fade * In.ar(in, 2);
-				Out.ar(out, snd)
-			}.play(target:group, args: [
-				\out, out,
-				\in, inBus[i].index,
-				\time, fadeTime
-			]);
-		});
-	}
-
-	setSource { arg newFunction;
-		if (isFading, {
-			sourceQ = newFunction;
-		}, {
-			this.performFade(newFunction);
-		});
-	}
-
-	setFadeTime { arg time;
-		fadeTime = time;
-		fadeSynth.do({ arg synth; synth.set(\time, fadeTime); });
-	}
-
-	setControl { arg key, value;
-		controlLag[key].set(\value, value);
-	}
-
-	setControlLagTime { arg time;
-		controlLag.do({ arg synth; synth.set(\time, time); });
-	}
-
-	stop {
-		fadeSynth.do({ arg synth; synth.set(\gate, 0); });
-	}
-
-	free {
-		group.free;
-		inBus.do({ arg bus; bus.free; });
-		controlBus.do({ arg bus; bus.free; });
-	}
-
-	//////////////////////////////////////////
-	/// private
-
-	performFade { arg newFunction, args;
-		sourceIndex = if (sourceIndex > 0, {0}, {1});
-		// postln("performing fade; new source index = " ++ sourceIndex);
-
-		isFading = true;
-
-		// this Routine creates a new thread
-		// not the most robust solution if fade times are extremely short,
-		// but much simpler than synchronizing with events from the server.
-		Routine {
-			sourceLast = source;
-			source = newFunction.play(
-				outbus:inBus[sourceIndex].index,
-				target:group,
-				addAction:\addToHead // <- important
-			);
-
-			server.sync;
-
-			controls.do({ arg key;
-				source.map(key, controlBus[key]);
-			});
-
-			if ((args == nil).not, {
-				controls.do({ arg key;
-					if (args.includes(key), {
-						controlBus[key].set(args[key]);
-					})
-				})
-			});
-
-			fadeSynth[sourceIndex].set(\gate, 1);
-			fadeSynth[1-sourceIndex].set(\gate, 0);
-
-			(fadeTime + 0.001).wait;
-			this.finishFade;
-		}.play;
-	}
-
-	finishFade {
-		if ((sourceLast== nil).not, {
-			sourceLast.free;
-		});
-
-		isFading = false;
-
-		if ((sourceQ == nil).not, {
-			this.performFade(sourceQ);
-			sourceQ = nil;
-		});
-	}
+*new {
+arg server,      // instance of Server
+out,             // output bus index
+controls;        // array of control names; source synth functions should accept these args
+^super.new.init(server, out, controls);
 }
+
+init {
+arg s, out, ctl;
+
+server = s;
+controls = ctl.asSet;
+
+source = nil;
+sourceLast = nil;
+sourceQ = nil;
+
+sourceIndex = 0;
+isFading = false;
+
+group = Group.new(server);
+inBus = Array.fill(2, { Bus.audio(s, 2) });
+
+controlBus = Dictionary.new;
+controlLag = Dictionary.new;
+controls.do({ arg name;
+controlBus[name] = Bus.control(s);
+controlLag[name] = {
+arg bus, value, time = 1.0;
+ReplaceOut.kr(bus, Lag.kr(value, time));
+}.play(target:group, args:[\bus, controlBus[name].index]);
+});
+
+fadeSynth = Array.fill(2, { arg i;
+{
+arg out=0, in, gate, time=4;
+var fade, snd;
+fade = EnvGen.ar(Env.asr(time, 1, time), gate);
+snd = fade * In.ar(in, 2);
+Out.ar(out, snd)
+}.play(target:group, args: [
+\out, out,
+\in, inBus[i].index,
+\time, fadeTime
+]);
+});
+}
+
+setSource { arg newFunction;
+if (isFading, {
+sourceQ = newFunction;
+}, {
+this.performFade(newFunction);
+});
+}
+
+setFadeTime { arg time;
+fadeTime = time;
+fadeSynth.do({ arg synth; synth.set(\time, fadeTime); });
+}
+
+setControl { arg key, value;
+controlLag[key].set(\value, value);
+}
+
+setControlLagTime { arg time;
+controlLag.do({ arg synth; synth.set(\time, time); });
+}
+
+stop {
+fadeSynth.do({ arg synth; synth.set(\gate, 0); });
+}
+
+free {
+group.free;
+inBus.do({ arg bus; bus.free; });
+controlBus.do({ arg bus; bus.free; });
+}
+
+//////////////////////////////////////////
+/// private
+
+performFade { arg newFunction, args;
+sourceIndex = if (sourceIndex > 0, {0}, {1});
+// postln("performing fade; new source index = " ++ sourceIndex);
+
+isFading = true;
+
+// this Routine creates a new thread
+// not the most robust solution if fade times are extremely short,
+// but much simpler than synchronizing with events from the server.
+Routine {
+sourceLast = source;
+source = newFunction.play(
+outbus:inBus[sourceIndex].index,
+target:group,
+addAction:\addToHead // <- important
+);
+
+server.sync;
+
+controls.do({ arg key;
+source.map(key, controlBus[key]);
+});
+
+if ((args == nil).not, {
+controls.do({ arg key;
+if (args.includes(key), {
+controlBus[key].set(args[key]);
+})
+})
+});
+
+fadeSynth[sourceIndex].set(\gate, 1);
+fadeSynth[1-sourceIndex].set(\gate, 0);
+
+(fadeTime + 0.001).wait;
+this.finishFade;
+}.play;
+}
+
+finishFade {
+if ((sourceLast== nil).not, {
+sourceLast.free;
+});
+
+isFading = false;
+
+if ((sourceQ == nil).not, {
+this.performFade(sourceQ);
+sourceQ = nil;
+});
+}
+}
+*/

--- a/engine/Engine_Dronecaster.sc
+++ b/engine/Engine_Dronecaster.sc
@@ -23,7 +23,7 @@ Dronecaster {
 			var def = socket.wrapDef(e.fullPath.load, name, server);
 			if (def.notNil, { drones[name] = def; });
 		});
-		drones.postln;
+		//drones.postln;
 
 
 		recordBus = Bus.audio(server, 2);
@@ -32,6 +32,7 @@ Dronecaster {
 	}
 
 	start { arg name;
+		postln("start requested for name: " ++ name);
 		if (drones.keys.includes(name), {
 			socket.setSource(drones[name]);
 		}, {
@@ -79,10 +80,12 @@ Engine_Dronecaster : CroneEngine {
 		//  :/
 		caster = Dronecaster.new(context.server, "/home/we/dust/code/dronecaster/engine/drones" );
 
+		/*
 		caster.drones.keys.do({ arg name;
 			("sending name: " ++ name).postln;
 			luaOscAddr.sendMsg("/add_drone", name);
 		});
+		*/
 
 		this.addCommand("hz", "f", { arg msg;
 			caster.setHz(msg[1].asFloat);

--- a/engine/Engine_Dronecaster.sc
+++ b/engine/Engine_Dronecaster.sc
@@ -10,6 +10,8 @@ Dronecaster {
 	}
 
 	init { arg server, baseDronePath;
+		socket = DroneCaster_SynthSocket.new(server, 0, [\hz, \amp]);
+		
 		if (baseDronePath == nil, {
 			baseDronePath = PathName(Document.current.path).pathOnly ++ "engine/drones";
 		});
@@ -18,11 +20,11 @@ Dronecaster {
 		drones = Dictionary.new;
 		PathName.new(baseDronePath).entries.do({|e|
 			var name = e.fileNameWithoutExtension;
-			drones[name] = DroneCaster_SynthSocket.wrapDef(e.fullPath.load, name);
+			var def = socket.wrapDef(e.fullPath.load, name, server);
+			if (def.notNil, { drones[name] = def; });
 		});
 		drones.postln;
 
-		socket = Dronecaster_SynthSocket.new(server, 0, [\amp, \hz]);
 
 		recordBus = Bus.audio(server, 2);
 		inJacks = { Out.ar(recordBus, SoundIn.ar([0, 1])) }.play;

--- a/engine/Engine_Dronecaster.sc
+++ b/engine/Engine_Dronecaster.sc
@@ -23,7 +23,7 @@ Dronecaster {
 			var def = socket.wrapDef(e.fullPath.load, name, server);
 			if (def.notNil, { drones[name] = def; });
 		});
-		//drones.postln;
+		drones.postln;
 
 
 		recordBus = Bus.audio(server, 2);
@@ -80,12 +80,10 @@ Engine_Dronecaster : CroneEngine {
 		//  :/
 		caster = Dronecaster.new(context.server, "/home/we/dust/code/dronecaster/engine/drones" );
 
-		/*
 		caster.drones.keys.do({ arg name;
 			("sending name: " ++ name).postln;
 			luaOscAddr.sendMsg("/add_drone", name);
 		});
-		*/
 
 		this.addCommand("hz", "f", { arg msg;
 			caster.setHz(msg[1].asFloat);

--- a/engine/Engine_Dronecaster.sc
+++ b/engine/Engine_Dronecaster.sc
@@ -13,12 +13,12 @@ Dronecaster {
 		if (baseDronePath == nil, {
 			baseDronePath = PathName(Document.current.path).pathOnly ++ "engine/drones";
 		});
-		postln("searching for drones at: " ++ baseDronePath);
+		postln("compiling drones in " ++ baseDronePath ++ "...");
 
 		drones = Dictionary.new;
 		PathName.new(baseDronePath).entries.do({|e|
 			var name = e.fileNameWithoutExtension;
-			drones[name] = e.fullPath.load
+			drones[name] = DroneCaster_SynthSocket.wrapDef(e.fullPath.load, name);
 		});
 		drones.postln;
 
@@ -31,13 +31,7 @@ Dronecaster {
 
 	start { arg name;
 		if (drones.keys.includes(name), {
-			socket.setSource({
-			    arg hz=440, amp=0.02, amplag=0.02, hzlag=0.01;
-			    var amp_, hz_;
-			    amp_ = Lag.ar(K2A.ar(amp), amplag);
-			    hz_ = Lag.ar(K2A.ar(hz), hzlag);
-			    drones[name].value(hz:hz_,amp:amp_);
-			});
+			socket.setSource(drones[name]);
 		}, {
 			postln("dronecaster does not know this drone: " ++ name);
 		});

--- a/engine/drones/Sachiko.scd
+++ b/engine/drones/Sachiko.scd
@@ -48,7 +48,7 @@
 	snd=Splay.ar(snd);
 
 	// global moog filter
-	snd=MoogFF.ar(snd.tanh,LinExp.kr(VarLag.kr(LFNoise0.kr(1/4),4,warp:\sine),-1,1,hz*10,18000).poll);
+	snd=MoogFF.ar(snd.tanh,LinExp.kr(VarLag.kr(LFNoise0.kr(1/4),4,warp:\sine),-1,1,hz*10,18000));
 
 	// reverb predelay time :
 	z = DelayN.ar(snd, 0.048);

--- a/engine/drones/UNEABLIN.scd
+++ b/engine/drones/UNEABLIN.scd
@@ -10,8 +10,11 @@
 	var fb = LocalIn.ar(n);
 	var modscale = LFTri.kr(1/(dt*4), 0).squared * 0.34;
 	var mod = ratios.collect({|r, i| LFSaw.kr(1/(dt*r*7+i), i.linlin(0, n-1, 3, 0) + 0.125.rand, modscale) });
+	var del = ratios.collect({ |r, i|
+		BufDelayL.ar(delbuf, fb.wrapAt(i+1), LFSaw.ar(1/(dt*r*4+i), i*2/n))
+	});
 	var phase = ratios.collect({|r,i|
-		BufDelayL.ar(delbuf, fb.wrapAt(i+1), LFSaw.ar(1/(dt*r*4+i), i*2/n).linlin(-1, 1, 1/16, 7.99).lagud(0.0077, 0.0277)) * mod[i]
+		del[i].linlin(-1, 1, 1/16, 7.99).lagud(0.0077, 0.0277) * mod[i]
 	});
 	var oscs;
 	var rqmod;
@@ -29,16 +32,15 @@
 	});
 
 	hz = hz.lag(4.0);
-	LocalOut.ar(oscs);
+	LocalOut.ar(oscs.reverse);
 	snd = Array.fill(n, {arg i;
 		Pan2.ar(oscs[i], SinOscFB.ar(1/dt, LFTri.kr(1/(dt * ratios[i]), i.linlin(0,n-1,1,7), 0.8)));
 	});
+	snd = snd + del.flatten.clump(2) * 0.29;
 	rqmod = LFTri.kr(1/(dt * ratios * ratios.sum), 0.2.rand, 0.1, 0.34/amps.rotate(5));
-	//rqmod.poll;
 	snd = RLPF.ar(snd, (hz*ratios.rotate(1) * 2), rqmod);
 	snd = Mix.new(snd.flatten.clump(2)) / n;
 	snd = snd * amp * 0.3 * Linen.kr(attackTime:5.55);
-	//Peak.kr(Amplitude.kr(snd)).ampdb.poll;
 	snd;
 }
 //.play(s);


### PR DESCRIPTION
these changes may be presumptous or undesired.

a bunch of things were architecturally iffy, causing race conditions, weird timing, errors, scary warnings, and sometimes supercollider failures.
- compiling these huge synthdefs on the fly
- sending them over OSC instead of loading via disk
- using crossfades. some of these defs can barely fit in the interconnect/memory budget, and 2x is too many.
- using OSC channel to inform lua of drones. (this race condition is the cause of the "nil" errors when selecting drones from the parameters list.)


so here are a number of changes:

engine side:
- all synthdefs are wrapped, compiled and written to disk on engine init. 
  - downside: this means it now takes several seconds to load the script. (you can see progress in the supercollider REPL, which also reveals which drones have super huge graphs.)
  - upside: starting a drone is now immediate.
  
- instead of crossfading, there is now a fade-out, followed by a fade-in when the old synth is completely done. 
- while the fade-out is occuring, requesting a new drone just replaces the cued synthdef.

- no sending OSC for the drone list

script side:
- drone list is scraped from disk. this is still asynchronous, but it's a single point of  
synchronization, which we perform by wrapping the  body of `init` in a system_cmd callback.
- drone selection parameter is an option type.