### PR TITLE
Fix ar bufnum, mixdown, uns

### DIFF
--- a/engine/Dronecaster_SynthSocket.sc
+++ b/engine/Dronecaster_SynthSocket.sc
@@ -19,7 +19,7 @@ DroneCaster_SynthSocket {
 			arg hz, amp=1, out=0, gate=1, attack=1.0, release=1.0;
 
 			var aenv, snd;
-			snd = { fn.value(K2A.ar(hz), K2A.ar(amp), K2A.ar(buf.bufnum)) }.try { 
+			snd = { fn.value(K2A.ar(hz), K2A.ar(amp), buf.bufnum) }.try { 
 				arg err;				
 				postln("failed to wrap ugen graph! error:");
 				err.postln;
@@ -27,9 +27,6 @@ DroneCaster_SynthSocket {
 				[Silent.ar]
 			};
 			aenv = EnvGen.kr(Env.asr(attack, 1, release), gate, doneAction:2);
-			// force mix down to stereo (interleaved)
-			snd = Mix.new(snd.flatten.clump(2)) * aenv;
-			
 			Out.ar(out, snd);
 		});
 		if (nope, {

--- a/engine/drones/UNEABLIN.scd
+++ b/engine/drones/UNEABLIN.scd
@@ -1,25 +1,25 @@
 // @zebra
 //z =
 {
-	arg hz=110, amp=1, dt=23;
+	arg hz=110, amp=0.4; //, dt=23;
 	var delbuf= LocalBuf.new(SampleRate.ir * 8.0);
 
+	var dt = 23;
 	var ratios = [1, 3/2, 2, 6/5, 9/5, 1/2];
 	var amps = [2, -6, 0, -8, -9, -5, -10, -4].dbamp;
 	var n = ratios.size;
 	var fb = LocalIn.ar(n);
 	var modscale = LFTri.kr(1/(dt*4), 0).squared * 0.34;
 	var mod = ratios.collect({|r, i| LFSaw.kr(1/(dt*r*7+i), i.linlin(0, n-1, 3, 0) + 0.125.rand, modscale) });
-	var del = ratios.collect({ |r, i|
-		BufDelayL.ar(delbuf, fb.wrapAt(i+1), LFSaw.ar(1/(dt*r*4+i), i*2/n))
-	});
 	var phase = ratios.collect({|r,i|
-		del[i].linlin(-1, 1, 1/16, 7.99).lagud(0.0077, 0.0277) * mod[i]
+		BufDelayL.ar(delbuf, fb.wrapAt(i+1), LFSaw.ar(1/(dt*r*4+i), i*2/n).linlin(-1, 1, 1/16, 7.99).lagud(0.0077, 0.0277)) * mod[i]
 	});
 	var oscs;
 	var rqmod;
 	var snd;
 	var dst = { arg x; (x * 1.5) - (x.cubed * 0.5) };
+
+	// amp.poll;
 
 	oscs = ratios.collect({ arg r, i;
 		var x = SinOsc.ar(hz * r + [r*0.25, r* -0.25], phase.wrapAt(i+2), amps[i]);
@@ -32,15 +32,16 @@
 	});
 
 	hz = hz.lag(4.0);
-	LocalOut.ar(oscs.reverse);
+	LocalOut.ar(oscs);
 	snd = Array.fill(n, {arg i;
 		Pan2.ar(oscs[i], SinOscFB.ar(1/dt, LFTri.kr(1/(dt * ratios[i]), i.linlin(0,n-1,1,7), 0.8)));
 	});
-	snd = snd + del.flatten.clump(2) * 0.29;
 	rqmod = LFTri.kr(1/(dt * ratios * ratios.sum), 0.2.rand, 0.1, 0.34/amps.rotate(5));
+	//rqmod.poll;
 	snd = RLPF.ar(snd, (hz*ratios.rotate(1) * 2), rqmod);
 	snd = Mix.new(snd.flatten.clump(2)) / n;
 	snd = snd * amp * 0.3 * Linen.kr(attackTime:5.55);
+	//Peak.kr(Amplitude.kr(snd)).ampdb.poll;
 	snd;
 }
 //.play(s);

--- a/engine/drones/UNMEMQUA.scd
+++ b/engine/drones/UNMEMQUA.scd
@@ -1,7 +1,8 @@
 // @zebra
 //z =
 {
-	arg hz=110, amp=1.0, decay=1.0,
+	arg hz=110, amp=1.0;
+	var decay=1.0,
 	dustDensity=7, dustLagUp=0.017, dustLagDown=0.07,
 	dustAmp=0.73, brownAmp=0.03, pinkAmp=0.03, sineAmp=0.011, rlpfAmp=0.33,
 	sineHzRatio=0.25, decayRatio=256;

--- a/engine/drones/UNRELACC.scd
+++ b/engine/drones/UNRELACC.scd
@@ -1,7 +1,8 @@
 // @zebra
 //z =
 {
-	arg hz=110, amp=1.0, hzRatio=2.0;
+	arg hz=110, amp=1.0; //, hzRatio=2.0;
+	var hzRatio=2.0;
 	var snd;
 	var aaa, bbb;
 	var ratios = [0.5, 1, 4/3, 7/4, 2, 12/5];
@@ -21,6 +22,7 @@
 	});
 	snd = LeakDC.ar(snd, 0.994);
 	snd = Mix.new(snd.flatten.clump(2));
+	snd.postln;
 	snd = snd * amp * -6.dbamp * Linen.kr(attackTime:6.66);
 	// Peak.kr(Amplitude.kr(snd)).ampdb.poll;
 	snd;

--- a/engine/drones/UNWEALNE.scd
+++ b/engine/drones/UNWEALNE.scd
@@ -1,7 +1,8 @@
 // @zebra
 //z =
 {
-	arg hz=110, amp=1.0, spring=0.253, damp=0.0088, decay=12.0, fbamt=0.1, crack=1.97;
+	arg hz=110, amp=1.0; //, //spring=0.253, damp=0.0088, decay=12.0, fbamt=0.1, crack=1.97;
+	var spring=0.253, damp=0.0088, decay=12.0, fbamt=0.1, crack=1.97;
 	var r1 = [0.25, 0.5, 1, 3, 2, 9/4, 10/4];
 	var r2 =[1, 3/2, 2, 9/4, 8/3, 14/4];
 	var amps = [0, 0, 2, -9, -4, -9, -12].dbamp;


### PR DESCRIPTION
this combines 2 small changes to the "synth socket" class, with fixes to make UNs worth with latest version. (sorry for the combo...)

-----

every few months i run this script and discover that UNs are broken again in some weird way. i think it must be ghosts. 

anyway, this time there was an explicable reason: the addition of a third argument (buffer number) to the graph function call : https://github.com/northern-information/dronecaster/blame/main/engine/Dronecaster_SynthSocket.sc#L22

this broke all the UNs functions, because they all take more than 2 arguments (sometimes many more) with default values. passing a buf number to some of those made super super crazy things happen - actually crashed scsynth in one instance by setting hz = x/0 or something.

anyways the fix here is to move all the extra arguments to constant-valued variables.

----

in passing i noticed a couple things with the socket class:

- the new buffer argument doesn't need to be made audio rate (indeed i don't think it should be, that is the other main contender for cause of crash i witnessed.) the only reason for the audio rate wrappers around other args is that some of the drones (e.g. dreamcrusher) will crash otherwise since they supply their argument to a `Lag.ar`.

- i noticed that the forced-stereo mixdown thing i added can have unexpected results depending on the shape of the input array and level of nesting. it seems better just to remove it and put the onus on graph functions to ensure their outputs are stereo (or i guess that they only care about the first 2 channels.) it would be nice to have a universal-dynamic-stereo-mixdown-thing but this isn't it.
