### PR TITLE
fix socket typos, additional tweaks

### DIFF
--- a/engine/Dronecaster_SynthSocket.sc
+++ b/engine/Dronecaster_SynthSocket.sc
@@ -19,15 +19,15 @@ DroneCaster_SynthSocket {
 			arg hz, amp=1, out=0, gate=1, attack=1.0, release=1.0;
 
 			var aenv, snd;
-			snd = { fn.value(K2A.ar(hz), K2A.ar(amp), buf.bufnum) }.try { 
-				arg err;				
+			snd = { fn.value(K2A.ar(hz), K2A.ar(amp), buf.bufnum) }.try {
+				arg err;
 				postln("failed to wrap ugen graph! error:");
 				err.postln;
 				nope = true;
 				[Silent.ar]
 			};
 			aenv = EnvGen.kr(Env.asr(attack, 1, release), gate, doneAction:2);
-			Out.ar(out, snd);
+			Out.ar(out, snd * aenv);
 		});
 		if (nope, {
 			^nil
@@ -39,6 +39,7 @@ DroneCaster_SynthSocket {
 
 
 	stop {
+		postln("stopping...");
 		if (synth.notNil, {
 			synth.set(\gate, 0);
 		});
@@ -65,7 +66,7 @@ DroneCaster_SynthSocket {
 	setFadeTime { arg t;
 		fadeTime = t;
 		if (synth.notNil, {
-			synth.set(\atteck, fadeTime);
+			synth.set(\attack, fadeTime);
 			synth.set(\release, fadeTime);
 		});
 	}
@@ -118,11 +119,11 @@ DroneCaster_SynthSocket {
 			controls.keys.do({ arg k;
 				controlVals[k] = controls[k].getSynchronous;
 			});
-			
+
 			synthArgs = [\out, out, \attack, fadeTime, \release, fadeTime] ++ controlVals.getPairs;
 			postln("synthArgs = " ++ synthArgs);
 			postf("cuedSource = % (%)\n", cuedSource, cuedSource.name);
-			
+
 			synth = Synth.new(cuedSource.name, synthArgs, target:group);
 			postf("new synth = %\n; mapping...\n", synth);
 			controls.keys.do({ arg k; synth.map(k, controls[k]); });

--- a/engine/Engine_Dronecaster.sc
+++ b/engine/Engine_Dronecaster.sc
@@ -11,7 +11,7 @@ Dronecaster {
 
 	init { arg server, baseDronePath;
 		socket = DroneCaster_SynthSocket.new(server, 0, [\hz, \amp]);
-		
+
 		if (baseDronePath == nil, {
 			baseDronePath = PathName(Document.current.path).pathOnly ++ "engine/drones";
 		});
@@ -68,8 +68,9 @@ Dronecaster {
 // norns glue
 Engine_Dronecaster : CroneEngine {
 	classvar luaOscPort = 10111;
+	classvar <>dronePath = "/home/we/dust/code/dronecaster/engine/drones" ;
 
-	var caster; // a Dronecaster
+	var <caster; // a Dronecaster
 	*new { arg context, doneCallback;
 		^super.new(context, doneCallback);
 	}
@@ -81,7 +82,7 @@ Engine_Dronecaster : CroneEngine {
 		this.addCommand("initialize", "ff", { arg msg;
 			if (caster==nil,{
 				//  :/
-				caster = Dronecaster.new(context.server, "/home/we/dust/code/dronecaster/engine/drones" );
+				caster = Dronecaster.new(context.server, dronePath);
 				// caster.drones.keys.do({ arg name;
 				// 	("sending name: " ++ name).postln;
 				// 	luaOscAddr.sendMsg("/add_drone", name);


### PR DESCRIPTION
- typo make initial attack time variable not work
- amplitude envelope wasn't applied!
- make `dronePath` class variable for `DroneCaster`, for easier off-norns use
- make `caster` engine variable readable, for easier off-norns use